### PR TITLE
use extension rather than require

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -18,7 +18,7 @@ FITSHeadersMappedBuffersExt = ["MappedBuffers"]
 Compat = "2, 3, 4"
 MappedBuffers = "0.1"
 TypeUtils = "0.2, 0.3, 1"
-julia = "1.9"
+julia = "1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -6,14 +6,19 @@ version = "0.4.2"
 [deps]
 Compat = "34da2185-b29b-5c13-b0c7-acf172513d20"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
-Requires = "ae029012-a4dd-5104-9daa-d747884805df"
 TypeUtils = "c3b1956e-8857-4d84-9b79-890df85b1e67"
+
+[weakdeps]
+MappedBuffers = "010f96a2-bf57-4630-84b9-647e6f9999c4"
+
+[extensions]
+FITSHeadersMappedBuffersExt = ["MappedBuffers"]
 
 [compat]
 Compat = "2, 3, 4"
-Requires = "1"
+MappedBuffers = "0.1"
 TypeUtils = "0.2, 0.3, 1"
-julia = "1"
+julia = "1.9"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/ext/FITSHeadersMappedBuffersExt.jl
+++ b/ext/FITSHeadersMappedBuffersExt.jl
@@ -1,0 +1,9 @@
+module FITSHeadersMappedBuffersExt
+
+using FITSHeaders
+using MappedBuffers
+
+FITSHeaders.Parser.PointerCapability(::Type{<:MappedBuffers.MappedBuffer}) =
+    FITSHeaders.Parser.PointerFull()
+
+end # module

--- a/src/FITSHeaders.jl
+++ b/src/FITSHeaders.jl
@@ -31,8 +31,6 @@ export
     FITS_BLOCK_SIZE,
     FITS_SHORT_KEYWORD_SIZE
 
-using Requires
-
 # Enumeration of keyword value type identifiers.
 @enum FitsCardType::Cint begin
     FITS_LOGICAL   = 0
@@ -97,12 +95,5 @@ import .Headers:
 include("public.jl")
 
 include("deprecated.jl")
-
-function __init__()
-    @require MappedBuffers="010f96a2-bf57-4630-84b9-647e6f9999c4" begin
-        FITSHeaders.Parser.PointerCapability(::Type{<:MappedBuffers.MappedBuffer}) =
-            FITSHeaders.Parser.PointerFull()
-    end
-end
 
 end # module


### PR DESCRIPTION
This pull request introduces an extension module to provide compatibility between `FITSHeaders` and `MappedBuffers`, and removes old conditional initialization code from the main module.  This eliminate runtime conditional loading of `MappedBuffers` support that cause dynamic dispatch and prevent the use of JuliaC --trim

However, that prevent the use of julia<1.9